### PR TITLE
Add symbol extensions

### DIFF
--- a/codec/src/commonMain/kotlin/com/inkapplications/ack/codec/position/CompressedPositionChunker.kt
+++ b/codec/src/commonMain/kotlin/com/inkapplications/ack/codec/position/CompressedPositionChunker.kt
@@ -19,7 +19,7 @@ internal object CompressedPositionChunker: Chunker<PositionReport.Compressed> {
         return Chunk(
             result = PositionReport.Compressed(
                 coordinates = GeoCoordinates(latitude, longitude),
-                symbol = symbolOf(tableIdentifier, codeIdentifier),
+                symbol = symbolOf(codeIdentifier, tableIdentifier),
                 extension = extension
             ),
             remainingData = data.substring(13)

--- a/codec/src/commonMain/kotlin/com/inkapplications/ack/codec/position/PlainPositionChunker.kt
+++ b/codec/src/commonMain/kotlin/com/inkapplications/ack/codec/position/PlainPositionChunker.kt
@@ -14,8 +14,8 @@ internal object PlainPositionChunker: Chunker<PositionReport.Plain> {
 
         val coordinates = GeoCoordinates(latitude, longitude)
         val symbol = symbolOf(
-            tableIdentifier = tableIdentifier,
-            codeIdentifier = codeIdentifier
+            id = codeIdentifier,
+            table = tableIdentifier
         )
         val symbolEmbeddedPosition = PositionReport.Plain(coordinates, symbol)
 

--- a/codec/src/commonMain/kotlin/com/inkapplications/ack/codec/position/PositionCodec.kt
+++ b/codec/src/commonMain/kotlin/com/inkapplications/ack/codec/position/PositionCodec.kt
@@ -72,7 +72,7 @@ object PositionCodec {
         signalInfo: SignalInfo? = null,
         windData: WindData? = null,
     ): String {
-        val (table, code) = symbol.toTableCodePair()
+        val (id, table) = symbol.toIdTablePair()
         val latitude = PlainPositionStringCodec.encodeLatitude(coordinates.latitude)
         val longitude = PlainPositionStringCodec.encodeLongitude(coordinates.longitude)
         val extra = when {
@@ -104,7 +104,7 @@ object PositionCodec {
             else -> ""
         }
 
-        return "$latitude$table$longitude$code$extra"
+        return "$latitude$table$longitude$id$extra"
     }
 
     private fun encodeCompressed(
@@ -115,10 +115,10 @@ object PositionCodec {
         range: Length? = null,
         windData: WindData? = null,
     ): String {
-        val (table, code) = symbol.toTableCodePair()
+        val (id, table) = symbol.toIdTablePair()
         val latitude = CompressedPositionStringTransformer.encodeLatitude(coordinates.latitude)
         val longitude = CompressedPositionStringTransformer.encodeLongitude(coordinates.longitude)
-        val encodedLocation = "$table$latitude$longitude$code"
+        val encodedLocation = "$table$latitude$longitude$id"
         val compressionInfo = Base91.encode(0b0_0_1_10_000)
         val extra = when {
             trajectory != null -> CompressedExtraStringCodec.encodeTrajectory(trajectory)

--- a/codec/src/commonTest/kotlin/com/inkapplications/ack/codec/item/ItemTransformerTest.kt
+++ b/codec/src/commonTest/kotlin/com/inkapplications/ack/codec/item/ItemTransformerTest.kt
@@ -27,7 +27,7 @@ class ItemTransformerTest {
         assertEquals(ReportState.Live, result.state)
         assertEquals(49.0583, result.coordinates.latitude.asDecimal, 0.0001)
         assertEquals(-72.0292, result.coordinates.longitude.asDecimal, 0.0001)
-        assertEquals(symbolOf('/', 'A'), result.symbol)
+        assertEquals(symbolOf('A', '/'), result.symbol)
     }
 
     @Test
@@ -40,7 +40,7 @@ class ItemTransformerTest {
         assertEquals(ReportState.Kill, result.state)
         assertEquals(49.0583, result.coordinates.latitude.asDecimal, 0.0001)
         assertEquals(-72.0292, result.coordinates.longitude.asDecimal, 0.0001)
-        assertEquals(symbolOf('/', 'A'), result.symbol)
+        assertEquals(symbolOf('A', '/'), result.symbol)
     }
 
     @Test
@@ -54,7 +54,7 @@ class ItemTransformerTest {
             name = "AID #2",
             state = ReportState.Live,
             coordinates = GeoCoordinates(49.0583.latitude, (-72.0292).longitude),
-            symbol = symbolOf('/', 'A'),
+            symbol = symbolOf('A', '/'),
             comment = "Hello World",
             altitude = null,
             trajectory = null,
@@ -80,7 +80,7 @@ class ItemTransformerTest {
             name = "AID #2",
             state = ReportState.Kill,
             coordinates = GeoCoordinates(49.0583.latitude, (-72.0292).longitude),
-            symbol = symbolOf('/', 'A'),
+            symbol = symbolOf('A', '/'),
             comment = "Hello World",
             altitude = null,
             trajectory = null,

--- a/codec/src/commonTest/kotlin/com/inkapplications/ack/codec/item/ObjectTransformerTest.kt
+++ b/codec/src/commonTest/kotlin/com/inkapplications/ack/codec/item/ObjectTransformerTest.kt
@@ -72,7 +72,7 @@ class ObjectTransformerTest {
             name = "LEADER",
             state = ReportState.Live,
             coordinates = GeoCoordinates(49.0583.latitude, (-72.0292).longitude),
-            symbol = symbolOf('/', '>'),
+            symbol = symbolOf('>', '/'),
             comment = "Hello World",
             altitude = null,
             trajectory = null,

--- a/codec/src/commonTest/kotlin/com/inkapplications/ack/codec/position/PositionCodecTest.kt
+++ b/codec/src/commonTest/kotlin/com/inkapplications/ack/codec/position/PositionCodecTest.kt
@@ -20,7 +20,7 @@ class PositionCodecTest {
         val result = PositionCodec.encodeBody(
             config = EncodingConfig(),
             coordinates = GeoCoordinates(49.5.latitude, (-72.75).longitude),
-            symbol = symbolOf('/', '>'),
+            symbol = symbolOf('>', '/'),
         )
 
         assertEquals("/5L!!<*e7>  Q", result)
@@ -33,7 +33,7 @@ class PositionCodecTest {
                 compression = EncodingPreference.Disfavored
             ),
             coordinates = GeoCoordinates(49.5.latitude, (-72.75).longitude),
-            symbol = symbolOf('/', '>'),
+            symbol = symbolOf('>', '/'),
         )
 
         assertEquals("4930.00N/07245.00W>", result)
@@ -46,7 +46,7 @@ class PositionCodecTest {
                 compression = EncodingPreference.Barred
             ),
             coordinates = GeoCoordinates(49.5.latitude, (-72.75).longitude),
-            symbol = symbolOf('/', '>'),
+            symbol = symbolOf('>', '/'),
         )
 
         assertEquals("4930.00N/07245.00W>", result)
@@ -60,7 +60,7 @@ class PositionCodecTest {
                     compression = EncodingPreference.Required
                 ),
                 coordinates = GeoCoordinates(49.5.latitude, (-72.75).longitude),
-                symbol = symbolOf('/', '>'),
+                symbol = symbolOf('>', '/'),
                 signalInfo = SignalInfo(
                     strength = Strength(2),
                     direction = Cardinal.South.toAngle(),
@@ -79,7 +79,7 @@ class PositionCodecTest {
                     compression = EncodingPreference.Barred
                 ),
                 coordinates = GeoCoordinates(49.5.latitude, (-72.75).longitude),
-                symbol = symbolOf('/', '>'),
+                symbol = symbolOf('>', '/'),
                 altitude = 10004.feet,
             )
         }
@@ -91,7 +91,7 @@ class PositionCodecTest {
             PositionCodec.encodeBody(
                 config = EncodingConfig(),
                 coordinates = GeoCoordinates(49.5.latitude, (-72.75).longitude),
-                symbol = symbolOf('/', '>'),
+                symbol = symbolOf('>', '/'),
                 altitude = 10004.feet,
                 signalInfo = SignalInfo(
                     strength = Strength(2),
@@ -108,7 +108,7 @@ class PositionCodecTest {
         val result = PositionCodec.encodeBody(
             config = EncodingConfig(),
             coordinates = GeoCoordinates(49.5.latitude, (-72.75).longitude),
-            symbol = symbolOf('/', '>'),
+            symbol = symbolOf('>', '/'),
             altitude = 10004.feet,
         )
 
@@ -120,7 +120,7 @@ class PositionCodecTest {
         val result = PositionCodec.encodeBody(
             config = EncodingConfig(),
             coordinates = GeoCoordinates(49.5.latitude, (-72.75).longitude),
-            symbol = symbolOf('/', '>'),
+            symbol = symbolOf('>', '/'),
             range = 20.miles,
         )
 
@@ -132,7 +132,7 @@ class PositionCodecTest {
         val result = PositionCodec.encodeBody(
             config = EncodingConfig(),
             coordinates = GeoCoordinates(49.5.latitude, (-72.75).longitude),
-            symbol = symbolOf('/', '>'),
+            symbol = symbolOf('>', '/'),
             trajectory = Trajectory(88.degrees, 36.2.knots),
         )
 
@@ -144,7 +144,7 @@ class PositionCodecTest {
         val result = PositionCodec.encodeBody(
             config = EncodingConfig(),
             coordinates = GeoCoordinates(49.5.latitude, (-72.75).longitude),
-            symbol = symbolOf('/', '>'),
+            symbol = symbolOf('>', '/'),
             directionReport = DirectionReport(
                 trajectory = 88.degrees at 36.knots,
                 bearing = 270.degrees,
@@ -164,7 +164,7 @@ class PositionCodecTest {
         val result = PositionCodec.encodeBody(
             config = EncodingConfig(),
             coordinates = GeoCoordinates(49.5.latitude, (-72.75).longitude),
-            symbol = symbolOf('/', '>'),
+            symbol = symbolOf('>', '/'),
             signalInfo = SignalInfo(
                 strength = Strength(2),
                 direction = Cardinal.South.toAngle(),
@@ -181,7 +181,7 @@ class PositionCodecTest {
         val result = PositionCodec.encodeBody(
             config = EncodingConfig(),
             coordinates = GeoCoordinates(49.5.latitude, (-72.75).longitude),
-            symbol = symbolOf('/', '>'),
+            symbol = symbolOf('>', '/'),
             transmitterInfo = TransmitterInfo(
                 power = 25.watts,
                 height = 20.feet,

--- a/codec/src/commonTest/kotlin/com/inkapplications/ack/codec/position/PositionParserTest.kt
+++ b/codec/src/commonTest/kotlin/com/inkapplications/ack/codec/position/PositionParserTest.kt
@@ -29,7 +29,7 @@ class PositionParserTest {
         assertEquals(49.0583, result.coordinates.latitude.asDecimal, 1e-4)
         assertEquals(-72.0291, result.coordinates.longitude.asDecimal, 1e-4)
         assertEquals("Test 001234", result.comment)
-        assertEquals(symbolOf('/', '-'), result.symbol)
+        assertEquals(symbolOf('-', '/'), result.symbol)
         assertFalse(result.supportsMessaging)
         assertNull(result.timestamp)
         assertNull(result.altitude)
@@ -49,7 +49,7 @@ class PositionParserTest {
         assertEquals(49.0583, result.coordinates.latitude.asDecimal, 1e-4)
         assertEquals(-72.0291, result.coordinates.longitude.asDecimal, 1e-4)
         assertEquals("Test 001234", result.comment)
-        assertEquals(symbolOf('/', '#'), result.symbol)
+        assertEquals(symbolOf('#', '/'), result.symbol)
         assertEquals(25.0, result.transmitterInfo?.power?.toWatts()!!.toDouble(), 1e-15)
         assertEquals(20.0, result.transmitterInfo?.height?.toFeet()!!.toDouble(), 1e-15)
         assertEquals(3.0, result.transmitterInfo?.gain?.toBels()?.value(Deci)!!.toDouble(), 1e-15)
@@ -72,7 +72,7 @@ class PositionParserTest {
         assertEquals(49.0583, result.coordinates.latitude.asDecimal, 1e-4)
         assertEquals(-72.0291, result.coordinates.longitude.asDecimal, 1e-4)
         assertEquals("Test", result.comment)
-        assertEquals(symbolOf('/', '-'), result.symbol)
+        assertEquals(symbolOf('-', '/'), result.symbol)
         assertFalse(result.supportsMessaging)
         assertNull(result.timestamp)
         assertEquals(1234.0, result.altitude?.toFeet()!!.toDouble())
@@ -101,7 +101,7 @@ class PositionParserTest {
         assertEquals(49.0583, result.coordinates.latitude.asDecimal, 1e-4)
         assertEquals(-72.0291, result.coordinates.longitude.asDecimal, 1e-4)
         assertEquals("Test1234", result.comment)
-        assertEquals(symbolOf('/', '>'), result.symbol)
+        assertEquals(symbolOf('>', '/'), result.symbol)
         assertEquals(expected, result.timestamp)
         assertFalse(result.supportsMessaging)
         assertNull(result.altitude)
@@ -122,7 +122,7 @@ class PositionParserTest {
         assertEquals(49.5, result.coordinates.latitude.asDecimal, 1e-1)
         assertEquals(-72.75, result.coordinates.longitude.asDecimal, 1e-2)
         assertEquals("Comment", result.comment)
-        assertEquals(symbolOf('/', '>'), result.symbol)
+        assertEquals(symbolOf('>', '/'), result.symbol)
         assertTrue(result.supportsMessaging)
         assertNull(result.timestamp)
         assertNull(result.altitude)
@@ -142,7 +142,7 @@ class PositionParserTest {
         assertEquals(49.5, result.coordinates.latitude.asDecimal, 1e-1)
         assertEquals(-72.75, result.coordinates.longitude.asDecimal, 1e-2)
         assertEquals("Comment", result.comment)
-        assertEquals(symbolOf('/', '>'), result.symbol)
+        assertEquals(symbolOf('>', '/'), result.symbol)
         assertFalse(result.supportsMessaging)
         assertNull(result.timestamp)
         assertNull(result.altitude)
@@ -171,7 +171,7 @@ class PositionParserTest {
         assertEquals(49.5, result.coordinates.latitude.asDecimal, 1e-1)
         assertEquals(-72.75, result.coordinates.longitude.asDecimal, 1e-2)
         assertEquals("Comment", result.comment)
-        assertEquals(symbolOf('/', '>'), result.symbol)
+        assertEquals(symbolOf('>', '/'), result.symbol)
         assertFalse(result.supportsMessaging)
         assertEquals(expected, result.timestamp)
         assertNull(result.altitude)
@@ -193,7 +193,7 @@ class PositionParserTest {
     fun generatePlainMinimum() {
         val given = PacketData.Position(
             coordinates = GeoCoordinates(49.0583.latitude, (-72.0291).longitude),
-            symbol = symbolOf('/', '-'),
+            symbol = symbolOf('-', '/'),
             comment = "Test 01234",
             timestamp = null,
             altitude = null,
@@ -214,7 +214,7 @@ class PositionParserTest {
     fun generateWithMessaging() {
         val given = PacketData.Position(
             coordinates = GeoCoordinates(49.0583.latitude, (-72.0291).longitude),
-            symbol = symbolOf('/', '-'),
+            symbol = symbolOf('-', '/'),
             comment = "Test 01234",
             timestamp = null,
             altitude = null,
@@ -243,7 +243,7 @@ class PositionParserTest {
             )
         val given = PacketData.Position(
             coordinates = GeoCoordinates(49.0583.latitude, (-72.0291).longitude),
-            symbol = symbolOf('/', '-'),
+            symbol = symbolOf('-', '/'),
             comment = "Test 01234",
             timestamp = Clock.System.now().withUtcValues(
                 dayOfMonth = 9,
@@ -278,7 +278,7 @@ class PositionParserTest {
             )
         val given = PacketData.Position(
             coordinates = GeoCoordinates(49.0583.latitude, (-72.0291).longitude),
-            symbol = symbolOf('/', '-'),
+            symbol = symbolOf('-', '/'),
             comment = "Test 01234",
             timestamp = Clock.System.now().withUtcValues(
                 dayOfMonth = 9,

--- a/codec/src/commonTest/kotlin/com/inkapplications/ack/codec/weather/WeatherParserTest.kt
+++ b/codec/src/commonTest/kotlin/com/inkapplications/ack/codec/weather/WeatherParserTest.kt
@@ -51,7 +51,7 @@ class WeatherParserTest {
         assertEquals(1.scale(Hundreths).inches, result.precipitation.rainLastHour)
         assertEquals(50.percent, result.humidity)
         assertEquals(9900.scale(Deka).pascals, result.pressure)
-        assertEquals(symbolOf('/', '_'), result.symbol)
+        assertEquals(symbolOf('_', '/'), result.symbol)
         assertNull(result.irradiance)
     }
 
@@ -73,7 +73,7 @@ class WeatherParserTest {
         assertNull(result.precipitation.rainLastHour)
         assertNull(result.humidity)
         assertNull(result.pressure)
-        assertEquals(symbolOf('/', '_'), result.symbol)
+        assertEquals(symbolOf('_', '/'), result.symbol)
         assertNull(result.irradiance)
     }
 
@@ -111,7 +111,7 @@ class WeatherParserTest {
         assertEquals(1.scale(Hundreths).inches, result.precipitation.rainLastHour)
         assertEquals(50.percent, result.humidity)
         assertEquals(9900.scale(Deka).pascals, result.pressure)
-        assertEquals(symbolOf('/', '_'), result.symbol)
+        assertEquals(symbolOf('_', '/'), result.symbol)
         assertNull(result.irradiance)
     }
 
@@ -133,7 +133,7 @@ class WeatherParserTest {
         assertNull(result.precipitation.rainLastHour)
         assertNull(result.humidity)
         assertNull(result.pressure)
-        assertEquals(symbolOf('/', '_'), result.symbol)
+        assertEquals(symbolOf('_', '/'), result.symbol)
         assertNull(result.irradiance)
     }
 
@@ -167,7 +167,7 @@ class WeatherParserTest {
                 rawRain = 789,
             ),
             coordinates = GeoCoordinates(49.0583.latitude, (-72.0291).longitude),
-            symbol = symbolOf('/', '_'),
+            symbol = symbolOf('_', '/'),
             temperature = (-7).fahrenheit,
             humidity = 50.percent,
             pressure = 9900.scale(Deka).pascals,
@@ -190,7 +190,7 @@ class WeatherParserTest {
             ),
             precipitation = Precipitation(),
             coordinates = GeoCoordinates(49.0583.latitude, (-72.0291).longitude),
-            symbol = symbolOf('/', '_'),
+            symbol = symbolOf('_', '/'),
             temperature = null,
             humidity = null,
             pressure = null,

--- a/structures/src/commonMain/kotlin/com/inkapplications/ack/structures/Symbol.kt
+++ b/structures/src/commonMain/kotlin/com/inkapplications/ack/structures/Symbol.kt
@@ -1,9 +1,10 @@
 package com.inkapplications.ack.structures
 
-private const val CHAR_RANGE_START = '!'
-private const val CHAR_RANGE_END = '~'
-private val SUPPORTS_OVERLAY = arrayOf('#','&','0','>','A','W','^','_','s','u','v','z')
-private val VALID_OVERLAY = ('0'..'9') + ('a'..'j') + ('A'..'Z') + '/' + '\\'
+import com.inkapplications.ack.structures.Symbol.Schema.ALTERNATE_TABLE
+import com.inkapplications.ack.structures.Symbol.Schema.PRIMARY_TABLE
+import com.inkapplications.ack.structures.Symbol.Schema.ALPHANUMERIC_OVERLAYS
+import com.inkapplications.ack.structures.Symbol.Schema.SYMBOL_RANGE
+import com.inkapplications.ack.structures.Symbol.Schema.VALID_OVERLAY
 
 /**
  * APRS Symbol data to describe a graphical symbol.
@@ -13,17 +14,22 @@ private val VALID_OVERLAY = ('0'..'9') + ('a'..'j') + ('A'..'Z') + '/' + '\\'
  *
  * http://www.aprs.org/symbols.html
  */
-sealed class Symbol {
-    abstract val id: Char
+sealed interface Symbol {
+    val id: Char
 
     /**
      * Symbol on the Primary table.
      */
-    data class Primary(override val id: Char): Symbol() {
+    data class Primary(override val id: Char): Symbol {
         init {
-            require(id in CHAR_RANGE_START..CHAR_RANGE_END) {
-                "Code Identifier '$id' out of bounds."
-            }
+            Schema.validate(id, PRIMARY_TABLE)
+        }
+
+        companion object {
+            /**
+             * All possible primary symbols.
+             */
+            val ALL = SYMBOL_RANGE.map { Primary(it) }
         }
     }
 
@@ -33,40 +39,144 @@ sealed class Symbol {
      * @param id The base symbol to use
      * @param overlay symbol indicating the overlay to use.
      */
-    data class Alternate(override val id: Char, val overlay: Char? = null): Symbol() {
+    data class Alternate(override val id: Char, val overlay: Char? = null): Symbol {
         /**
          * Whether the base symbol supports alphanumeric overlays.
          */
-        val alphaNumeric = id in SUPPORTS_OVERLAY
+        val alphaNumeric = id in ALPHANUMERIC_OVERLAYS
 
         init {
-            require(id in CHAR_RANGE_START..CHAR_RANGE_END) {
-                "Code Identifier '$id' out of bounds."
-            }
+            Schema.validate(id, overlay ?: ALTERNATE_TABLE)
             require(overlay == null || overlay in VALID_OVERLAY) {
-                "Table Identifier '$overlay' out of bounds."
+                "Overlay Identifier '$overlay' out of bounds."
+            }
+        }
+
+        companion object {
+            /**
+             * All of the base alternate symbols, not including overlays.
+             */
+            val BASE = SYMBOL_RANGE.map { Alternate(it) }
+        }
+    }
+
+    object Schema {
+        /**
+         * The character used to indicate the primary table.
+         */
+        const val PRIMARY_TABLE = '/'
+
+        /**
+         * The character used to indicate the alternate table.
+         */
+        const val ALTERNATE_TABLE = '\\'
+
+        /**
+         * The first character in the ASCII range that can be used for symbols.
+         */
+        const val CHAR_RANGE_START = '!'
+
+        /**
+         * The last character in the ASCII range that can be used for symbols.
+         */
+        const val CHAR_RANGE_END = '~'
+
+        /**
+         * The range of ASCII characters that can be used for symbols.
+         */
+        val SYMBOL_RANGE = CHAR_RANGE_START..CHAR_RANGE_END
+
+        /**
+         * List of symbol IDs that support alphanumeric overlays.
+         */
+        val ALPHANUMERIC_OVERLAYS = arrayOf('#','&','0','>','A','W','^','_','s','u','v','z')
+
+        /**
+         * List of valid overlay characters.
+         */
+        val VALID_OVERLAY = ('0'..'9') + ('a'..'z') + ('A'..'Z')
+
+        /**
+         * Validate whether a string is a valid symbol code.
+         */
+        fun validate(code: String) {
+            require(code.length == 2) { "Symbol Code must be 2 characters long." }
+            val (id, table) = code.toCharArray()
+            validate(id, table)
+        }
+
+        /**
+         * Validate whether a symbol id/table pair is valid.
+         */
+        fun validate(id: Char, table: Char) {
+            require(id in SYMBOL_RANGE) {
+                "Identifier '$id' out of bounds."
+            }
+            require(table == PRIMARY_TABLE || table == ALTERNATE_TABLE || table in VALID_OVERLAY) {
+                "Table Identifier '$table' out of bounds."
             }
         }
     }
 }
 
-fun Symbol.toTableCodePair() = when {
-    this is Symbol.Primary -> '/' to id
-    this is Symbol.Alternate && overlay != null -> overlay to id
-    else -> '\\' to id
+/**
+ * Convert a symbol to its id/table characters.
+ */
+fun Symbol.toIdTablePair() = when {
+    this is Symbol.Primary -> id to PRIMARY_TABLE
+    this is Symbol.Alternate && overlay != null -> id to overlay
+    else -> id to ALTERNATE_TABLE
 }
 
 /**
- * Create a symbol from a table/code pair.
- *
- * @param tableIdentifier Character identifying the table or an overlay for
- *        alternate symbols.
- * @param codeIdentifier Character identifying the base symbol on the specified table.
+ * Get the two-character code string for the Symbol.
  */
-fun symbolOf(tableIdentifier: Char, codeIdentifier: Char): Symbol {
-    return when (tableIdentifier) {
-        '/' -> Symbol.Primary(codeIdentifier)
-        '\\' -> Symbol.Alternate(codeIdentifier)
-        else -> Symbol.Alternate(codeIdentifier, tableIdentifier)
+val Symbol.code: String get() = toIdTablePair().let { "${it.first}${it.second}" }
+
+/**
+ * Create a symbol from a two-character code.
+ *
+ * @param code Two-character code identifying an APRS symbol
+ * @throws IllegalArgumentException if the code does not match a symbol schema.
+ * @return APRS symbol corresponding to the code.
+ */
+fun symbolOf(code: String): Symbol {
+    Symbol.Schema.validate(code)
+    return symbolOf(code[0], code[1])
+}
+
+/**
+ * Create a symbol from a two-character code.
+ *
+ * @param code Two-character code identifying an APRS symbol
+ * @return APRS symbol corresponding to the code, or null if the code is invalid.
+ */
+fun symbolOfOrNull(code: String): Symbol? {
+    return try {
+        symbolOf(code)
+    } catch (e: IllegalArgumentException) {
+        null
     }
+}
+
+/**
+ * Create a symbol from a id/table pair.
+ *
+ * @param table Character identifying the table or an overlay for
+ *        alternate symbols.
+ * @param id Character identifying the base symbol on the specified table.
+ */
+fun symbolOf(id: Char, table: Char): Symbol {
+    return when (table) {
+        PRIMARY_TABLE -> Symbol.Primary(id)
+        ALTERNATE_TABLE -> Symbol.Alternate(id)
+        else -> Symbol.Alternate(id, table)
+    }
+}
+
+@Deprecated("Renamed and inverted. Use toIdTablePair() instead, remembering to flip the pair.")
+fun Symbol.toTableCodePair() = when {
+    this is Symbol.Primary -> PRIMARY_TABLE to id
+    this is Symbol.Alternate && overlay != null -> overlay to id
+    else -> ALTERNATE_TABLE to id
 }

--- a/structures/src/commonTest/kotlin/com/inkapplications/ack/structures/SymbolTest.kt
+++ b/structures/src/commonTest/kotlin/com/inkapplications/ack/structures/SymbolTest.kt
@@ -1,0 +1,44 @@
+package com.inkapplications.ack.structures
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+
+class SymbolTest {
+    @Test
+    fun validSymbols() {
+        Symbol.Schema.validate("!/")
+        Symbol.Schema.validate("~/")
+        Symbol.Schema.validate("!\\")
+        Symbol.Schema.validate("~\\")
+        Symbol.Schema.validate("#A")
+        Symbol.Schema.validate("#Z")
+        Symbol.Schema.validate("#a")
+        Symbol.Schema.validate("#z")
+        Symbol.Schema.validate("#9")
+        Symbol.Schema.validate("#9")
+    }
+
+    @Test
+    fun invalidSymbols() {
+        assertFails { Symbol.Schema.validate("") }
+        assertFails { Symbol.Schema.validate("  ") }
+        assertFails { Symbol.Schema.validate(" ") }
+        assertFails { Symbol.Schema.validate("!/ ") }
+        assertFails { Symbol.Schema.validate("\uD83C\uDF55") }
+    }
+
+    @Test
+    fun createSymbol() {
+        assertEquals(Symbol.Primary('!'), symbolOf("!/"))
+        assertEquals(Symbol.Alternate('!'), symbolOf("!\\"))
+        assertEquals(Symbol.Alternate('!', 'B'), symbolOf("!B"))
+    }
+
+    @Test
+    fun codes() {
+        assertEquals("!/", Symbol.Primary('!').code)
+        assertEquals("!\\", Symbol.Alternate('!').code)
+        assertEquals("!B", Symbol.Alternate('!', 'B').code)
+    }
+}


### PR DESCRIPTION
Adds helpful extensions for working with APRS symbols

:warning: This also changes the order in the `symbolOf` functions to make them consistent.